### PR TITLE
Axe tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,23 @@
       "name": "yalesites-automated-tests",
       "version": "1.0.0",
       "license": "ISC",
+      "dependencies": {
+        "@axe-core/playwright": "^4.7.3"
+      },
       "devDependencies": {
         "@playwright/test": "^1.39.0",
         "@types/node": "^20.9.0"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.8.1.tgz",
+      "integrity": "sha512-KC1X++UdRAwMLRvB+BIKFheyLHUnbJTL0t0Wbv6TJMozn2V2QyEtAcN6jyUiudtGiLUGhHCtj/eWorBnVZ4dAA==",
+      "dependencies": {
+        "axe-core": "~4.8.2"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
       }
     },
     "node_modules/@playwright/test": {
@@ -35,6 +49,14 @@
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.8.2.tgz",
+      "integrity": "sha512-/dlp0fxyM3R8YW7MFzaHWXrf4zzbr0vaYb23VBFCl83R7nWNPg/yaQw2Dc8jzCMmDVLhSdzH8MjrsuIUuvX+6g==",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/fsevents": {
@@ -73,7 +95,6 @@
       "version": "1.39.0",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.39.0.tgz",
       "integrity": "sha512-+k4pdZgs1qiM+OUkSjx96YiKsXsmb59evFoqv8SKO067qBA+Z2s/dCzJij/ZhdQcs2zlTAgRKfeiiLm8PQ2qvw==",
-      "dev": true,
       "bin": {
         "playwright-core": "cli.js"
       },

--- a/package.json
+++ b/package.json
@@ -3,12 +3,19 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
-  "scripts": {},
+  "scripts": {
+    "test": "playwright test",
+    "a11y": "./scripts/a11y-sitemap-test",
+    "sitemap": "./scripts/retrieveSitemap"
+  },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "devDependencies": {
     "@playwright/test": "^1.39.0",
     "@types/node": "^20.9.0"
+  },
+  "dependencies": {
+    "@axe-core/playwright": "^4.7.3"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -29,7 +29,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: 'https://yalesites-platform.lndo.site',
+    baseURL: process.env.YALESITES_SITE || 'https://yalesites-platform.lndo.site',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',

--- a/scripts/a11y-sitemap-test
+++ b/scripts/a11y-sitemap-test
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+./scripts/retrieveSitemap "$1"
+playwright test ./tests/axe-sitemap.spec.ts

--- a/scripts/a11y-sitemap-test
+++ b/scripts/a11y-sitemap-test
@@ -1,4 +1,12 @@
 #!/usr/bin/env bash
 
-./scripts/retrieveSitemap "$1"
-playwright test ./tests/axe-sitemap.spec.ts
+if [ -z "$1" ] && [ -z "$YALESITES_SITE" ]
+  then
+    echo "Please provide a sitemap URL"
+    echo ""
+    echo "Usage: ./scripts/a11y-sitemap-test <sitemap-url>"
+    echo "or: npm run <cmd> -- <sitemap-url>"
+    echo "or: YALESITES_SITE=<site> npm run <cmd>"
+    exit 1
+fi
+./scripts/retrieveSitemap "$1" && playwright test ./tests/axe-sitemap.spec.ts

--- a/scripts/retrieveSitemap
+++ b/scripts/retrieveSitemap
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# If $1 is missing, attempt to get the environment variable YALESITES_SITE
+if [ -z "$1" ]; then
+    if [ -z "$YALESITES_SITE" ]; then
+        echo "Usage: retrieveSitemap <site>"
+        echo "Or:    YALESITES_SITE=<site> retrieveSitemap"
+        exit 1
+    fi
+fi
+
+SITE=${1:-$YALESITES_SITE}
+curl --insecure "$SITE/sitemap.xml" 2>/dev/null | xmllint --xpath '//*[local-name()="loc"]/text()' --format - > sitemap.links
+
+if [ ! -f sitemap.links ]; then
+    echo "Could not retrieve sitemap.xml"
+    exit 1
+fi
+
+echo "Retrieved sitemap.links"

--- a/scripts/visreg-sitemap-test
+++ b/scripts/visreg-sitemap-test
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+./scripts/retrieveSitemap "$1"
+playwright test ./tests/visreg-sitemap.spec.ts

--- a/sitemap.links
+++ b/sitemap.links
@@ -1,0 +1,13 @@
+https://starterkit.lndo.site/
+https://starterkit.lndo.site/events/2026-08-01-revitalize-past-events
+https://starterkit.lndo.site/events/2025-01-01-promote-your-events
+https://starterkit.lndo.site/about
+https://starterkit.lndo.site/posts
+https://starterkit.lndo.site/homepage
+https://starterkit.lndo.site/events
+https://starterkit.lndo.site/text-only-page
+https://starterkit.lndo.site/contact-us
+https://starterkit.lndo.site/example-landing-page
+https://starterkit.lndo.site/posts/2023-08-14-example-post
+https://starterkit.lndo.site/posts/2023-07-31-share-timely-updates
+https://starterkit.lndo.site/posts/2023-08-01-centering-inclusivity

--- a/support/a11y-page.ts
+++ b/support/a11y-page.ts
@@ -64,6 +64,7 @@ export const expect = baseExpect.extend({
     page: Page,
     tags: Array<string>,
     options?: { timeout?: number },
+    outputBuffer: typeof violationOutput = violationOutput,
   ) {
     const axePage = new AxePage(page, { tags, ...options });
     let pass: boolean;
@@ -83,7 +84,7 @@ export const expect = baseExpect.extend({
     const message = pass
       ? () => "True"
       : () => {
-          return violationOutput.outputViolations(results.violations);
+          return outputBuffer.outputViolations(results.violations);
         };
 
     return {

--- a/support/a11y-page.ts
+++ b/support/a11y-page.ts
@@ -1,0 +1,50 @@
+import { expect, type Page } from '@playwright/test'
+import AxeBuilder from "@axe-core/playwright";
+import type { Result, NodeResult } from "axe-core";
+
+export class AxePage {
+  private readonly axeBuilder: any
+  public results: Result[] = []
+
+  constructor(public readonly page: Page) {
+    this.axeBuilder = new AxeBuilder({ page })
+  }
+
+  async evaluate() {
+    this.results = await this.axeBuilder.analyze()
+    if (this.results.violations.length > 0) {
+      console.log(`Violations for ${this.page.url()}`)
+      this._outputViolations(this.results.violations)
+    }
+    expect(this.results.violations.length).toBe(0)
+    return this.results
+  }
+
+  private _outputViolations = (violations: Result[]) => {
+    violations.forEach((violation) => this._outputViolation(violation))
+  }
+
+  private _outputViolation = (violation: Result) => {
+    let { id, impact, description, nodes } = violation
+
+    console.log(`\n`)
+    console.log(`----------------------------------------`)
+    console.log(`Violation: ${id} (${impact})`)
+    console.log(`Description: ${description}`)
+    console.log(`Affected nodes:`)
+    this._outputNodes(nodes)
+  }
+
+  private _outputNodes = (nodes: NodeResult[]) => {
+    nodes.forEach((node) => this._outputNode(node))
+  }
+
+  private _outputNode = (node: NodeResult) => {
+    let { html, target } = node
+
+    console.log(`  ----------------`)
+    console.log(`  ${target}`)
+    console.log(`  ${html}`)
+    console.log(`  ${node.failureSummary}`)
+  }
+}

--- a/support/a11y-page.ts
+++ b/support/a11y-page.ts
@@ -42,7 +42,7 @@ const violationOutput = {
 }
 
 export const expect = baseExpect.extend({
-  async toBeAccessible(
+  async toPassAxe(
     page: Page,
     tags: Array<string>,
     options?: { timeout?: number },

--- a/support/a11y-page.ts
+++ b/support/a11y-page.ts
@@ -1,10 +1,10 @@
 import { expect, type Page } from '@playwright/test'
 import AxeBuilder from "@axe-core/playwright";
-import type { Result, NodeResult } from "axe-core";
+import type { Result, NodeResult, AxeResults } from "axe-core";
 
 export class AxePage {
   private readonly axeBuilder: any
-  public results: Result[] = []
+  public results: AxeResults
 
   constructor(public readonly page: Page, public readonly options = { tags: [] }) {
     let axeBuilder = new AxeBuilder({ page })

--- a/support/a11y-page.ts
+++ b/support/a11y-page.ts
@@ -6,6 +6,8 @@ import type { Result, NodeResult, AxeResults } from "axe-core";
  * Output axe result violations in a format that is easier to read.
  *
  * @param {Result[]} violations - An array of violations
+ * @param {integer} indentation - the number of 2 spaces to use as indention to
+ *                                output
  *
  * @returns {string} - A string with the violations formatted for output.
  *

--- a/support/a11y-page.ts
+++ b/support/a11y-page.ts
@@ -6,8 +6,12 @@ export class AxePage {
   private readonly axeBuilder: any
   public results: Result[] = []
 
-  constructor(public readonly page: Page) {
-    this.axeBuilder = new AxeBuilder({ page })
+  constructor(public readonly page: Page, public readonly options = { tags: [] }) {
+    let axeBuilder = new AxeBuilder({ page })
+    if (options.tags && options.tags.length > 0) {
+      axeBuilder.withTags(options.tags)
+    }
+    this.axeBuilder = axeBuilder
   }
 
   async evaluate() {

--- a/support/a11y-page.ts
+++ b/support/a11y-page.ts
@@ -2,9 +2,19 @@ import { expect as baseExpect, type Page } from "@playwright/test";
 import AxeBuilder from "@axe-core/playwright";
 import type { Result, NodeResult, AxeResults } from "axe-core";
 
+/*
+ * Output axe result violations in a format that is easier to read.
+ *
+ * @param {Result[]} violations - An array of violations
+ *
+ * @returns {string} - A string with the violations formatted for output.
+ *
+ */
 const violationOutput = {
   outputViolations: (violations: Result[]) => {
-    return violations.map((violation) => violationOutput._outputViolation(violation)).join('\n');
+    return violations
+      .map((violation) => violationOutput._outputViolation(violation))
+      .join("\n");
   },
 
   _outputViolation: (violation: Result) => {
@@ -12,18 +22,18 @@ const violationOutput = {
 
     let message = "";
 
-    message += (`\n`);
-    message += (`--------------------------------------------------------------------------------\n`);
-    message += (`Violation: ${id} (${impact})\n`);
-    message += (`Description: ${description}\n`);
-    message += (`Affected nodes:\n`);
+    message += `\n`;
+    message += `--------------------------------------------------------------------------------\n`;
+    message += `Violation: ${id} (${impact})\n`;
+    message += `Description: ${description}\n`;
+    message += `Affected nodes:\n`;
     message += violationOutput._outputNodes(nodes);
 
     return message;
   },
 
   _outputNodes: (nodes: NodeResult[]) => {
-    return nodes.map((node) => violationOutput._outputNode(node, 1)).join('\n');
+    return nodes.map((node) => violationOutput._outputNode(node, 1)).join("\n");
   },
 
   _outputNode: (node: NodeResult, indention = 0) => {
@@ -32,15 +42,23 @@ const violationOutput = {
     let indentionString = "  ".repeat(indention);
     let message = "";
 
-    message +=(`${indentionString}----------------------------------------\n`);
-    message +=(`${indentionString}${target}\n`);
-    message +=(`${indentionString}${html}\n`);
-    message +=(`${indentionString}${node.failureSummary}\n`);
+    message += `${indentionString}----------------------------------------\n`;
+    message += `${indentionString}${target}\n`;
+    message += `${indentionString}${html}\n`;
+    message += `${indentionString}${node.failureSummary}\n`;
 
     return message;
   },
-}
+};
 
+/*
+ * Extend the expect object with a new matcher to check for accessibility.
+ *
+ * @param {Page} page - The page to test
+ * @param {string[]} tags - An array of axe tags to test against
+ *
+ * @returns {object} - An object with the pass/fail results of the test.
+ */
 export const expect = baseExpect.extend({
   async toPassAxe(
     page: Page,
@@ -62,9 +80,11 @@ export const expect = baseExpect.extend({
       matcherResult = e.matcherResult;
     }
 
-    const message = pass ? () => "True" : () => {
-      return violationOutput.outputViolations(results.violations);
-    };
+    const message = pass
+      ? () => "True"
+      : () => {
+          return violationOutput.outputViolations(results.violations);
+        };
 
     return {
       message,
@@ -76,6 +96,9 @@ export const expect = baseExpect.extend({
   },
 });
 
+/*
+ * A wrapper around axe-core/playwright to make it easier to use.
+ */
 export class AxePage {
   private readonly axeBuilder: any;
   public results: AxeResults;
@@ -85,9 +108,11 @@ export class AxePage {
     public readonly options = { tags: [] },
   ) {
     let axeBuilder = new AxeBuilder({ page });
+
     if (options.tags && options.tags.length > 0) {
       axeBuilder.withTags(options.tags);
     }
+
     this.axeBuilder = axeBuilder;
   }
 

--- a/support/a11y-page.ts
+++ b/support/a11y-page.ts
@@ -1,54 +1,98 @@
-import { expect, type Page } from '@playwright/test'
+import { expect as baseExpect, type Page } from "@playwright/test";
 import AxeBuilder from "@axe-core/playwright";
 import type { Result, NodeResult, AxeResults } from "axe-core";
 
-export class AxePage {
-  private readonly axeBuilder: any
-  public results: AxeResults
+export const expect = baseExpect.extend({
+  async toBeAccessible(
+    page: Page,
+    tags: Array<string>,
+    options?: { timeout?: number },
+  ) {
+    const axePage = new AxePage(page, { tags, ...options });
+    let pass: boolean;
+    let matcherResult: any;
+    const expected = 0;
 
-  constructor(public readonly page: Page, public readonly options = { tags: [] }) {
-    let axeBuilder = new AxeBuilder({ page })
-    if (options.tags && options.tags.length > 0) {
-      axeBuilder.withTags(options.tags)
+    const results = await axePage.evaluate();
+
+    try {
+      baseExpect(results.violations.length).toBe(0);
+      pass = true;
+    } catch (e: any) {
+      pass = false;
+      matcherResult = e.matcherResult;
     }
-    this.axeBuilder = axeBuilder
+
+    const message = pass ? () => "True" : () => {
+      let message = `Violations for ${page.url()}\n`;
+      message += outputViolations(results.violations);
+
+      return message;
+    };
+
+    return {
+      message,
+      pass,
+      name: "toBeAccessible",
+      expected,
+      actual: matcherResult?.actual,
+    };
+  },
+});
+
+const outputViolations = (violations: Result[]) => {
+  return violations.map((violation) => _outputViolation(violation)).join('\n');
+};
+
+const _outputViolation = (violation: Result) => {
+  let { id, impact, description, nodes } = violation;
+
+  let message = "";
+
+  message += (`\n`);
+  message += (`----------------------------------------\n`);
+  message += (`Violation: ${id} (${impact})\n`);
+  message += (`Description: ${description}\n`);
+  message += (`Affected nodes:\n`);
+  message += _outputNodes(nodes);
+
+  return message;
+};
+
+const _outputNodes = (nodes: NodeResult[]) => {
+  return nodes.map((node) => _outputNode(node)).join('\n');
+};
+
+const _outputNode = (node: NodeResult) => {
+  let { html, target } = node;
+
+  let message = "";
+
+  message +=(`  ----------------\n`);
+  message +=(`  ${target}\n`);
+  message +=(`  ${html}\n`);
+  message +=(`  ${node.failureSummary}\n`);
+
+  return message;
+};
+
+export class AxePage {
+  private readonly axeBuilder: any;
+  public results: AxeResults;
+
+  constructor(
+    public readonly page: Page,
+    public readonly options = { tags: [] },
+  ) {
+    let axeBuilder = new AxeBuilder({ page });
+    if (options.tags && options.tags.length > 0) {
+      axeBuilder.withTags(options.tags);
+    }
+    this.axeBuilder = axeBuilder;
   }
 
   async evaluate() {
-    this.results = await this.axeBuilder.analyze()
-    if (this.results.violations.length > 0) {
-      console.log(`Violations for ${this.page.url()}`)
-      this._outputViolations(this.results.violations)
-    }
-    expect(this.results.violations.length).toBe(0)
-    return this.results
-  }
-
-  private _outputViolations = (violations: Result[]) => {
-    violations.forEach((violation) => this._outputViolation(violation))
-  }
-
-  private _outputViolation = (violation: Result) => {
-    let { id, impact, description, nodes } = violation
-
-    console.log(`\n`)
-    console.log(`----------------------------------------`)
-    console.log(`Violation: ${id} (${impact})`)
-    console.log(`Description: ${description}`)
-    console.log(`Affected nodes:`)
-    this._outputNodes(nodes)
-  }
-
-  private _outputNodes = (nodes: NodeResult[]) => {
-    nodes.forEach((node) => this._outputNode(node))
-  }
-
-  private _outputNode = (node: NodeResult) => {
-    let { html, target } = node
-
-    console.log(`  ----------------`)
-    console.log(`  ${target}`)
-    console.log(`  ${html}`)
-    console.log(`  ${node.failureSummary}`)
+    this.results = await this.axeBuilder.analyze();
+    return this.results;
   }
 }

--- a/support/login.ts
+++ b/support/login.ts
@@ -3,6 +3,13 @@ import { execSync, type ExecSyncOptions } from "child_process";
 const LOCAL_CMD = "lando drush uli";
 const REMOTE_CMD = "terminus drush ~ -- user:login";
 
+/*
+ * Get the admin login URL for the site whether local or on lando.
+ * 
+ * @param {string} path - path to the yalesites-project directory.
+ * 
+ * @returns {string} - the login URL.
+ */
 export default function getLoginUrl(path: string) : string {
   let pathToUse = path;
   if (!path) {

--- a/support/sitemap-links.ts
+++ b/support/sitemap-links.ts
@@ -1,0 +1,13 @@
+import * as fs from "fs";
+
+/*
+ * Given a filename, encoding, and a filter callback, return an array of links
+ * from the sitemap xml
+ */
+export default function getSitemapLinks(
+  filename: string,
+  encoding: BufferEncoding = "utf-8",
+  filterCallback: (link: string) => boolean = (link: string) => link !== "",
+) {
+  return fs.readFileSync(filename, encoding).split("\n").filter(filterCallback);
+}

--- a/support/sitemap-links.ts
+++ b/support/sitemap-links.ts
@@ -6,7 +6,8 @@ import * as fs from "fs";
  *
  * @param filename - The filename of the sitemap
  * @param encoding - The encoding of the sitemap (defaults to UTF-8)
- * @param filterCallback - A callback to filter the links (defaults to exclude empty lines)
+ * @param filterCallback - A callback to filter the links (defaults to exclude
+ *                         empty lines)
  *
  * @returns An array of links from the sitemap
  */
@@ -15,5 +16,13 @@ export default function getSitemapLinks(
   encoding: BufferEncoding = "utf-8",
   filterCallback: (link: string) => boolean = (link: string) => link !== "",
 ) {
-  return fs.readFileSync(filename, encoding).split("\n").filter(filterCallback);
+  try {
+    return fs
+      .readFileSync(filename, encoding)
+      .split("\n")
+      .filter(filterCallback);
+  } catch (err) {
+    console.log(err);
+    return null;
+  }
 }

--- a/support/sitemap-links.ts
+++ b/support/sitemap-links.ts
@@ -3,6 +3,12 @@ import * as fs from "fs";
 /*
  * Given a filename, encoding, and a filter callback, return an array of links
  * from the sitemap xml
+ *
+ * @param filename - The filename of the sitemap
+ * @param encoding - The encoding of the sitemap (defaults to UTF-8)
+ * @param filterCallback - A callback to filter the links (defaults to exclude empty lines)
+ *
+ * @returns An array of links from the sitemap
  */
 export default function getSitemapLinks(
   filename: string,

--- a/tests/axe-sitemap.spec.ts
+++ b/tests/axe-sitemap.spec.ts
@@ -1,0 +1,35 @@
+import { test as base, expect } from "@playwright/test";
+import { AxePage } from '@support/a11y-page';
+import fs from "fs";
+
+const axe_tags = [
+  "wcag2a",
+  "wcag2aa",
+  "wcag21a",
+  "wcag21aa",
+  // Uncomment to try WCAG 2.2 rules
+  // "wcag22a",
+  // "wcag22aa",
+  "best-practice", // Common accessibility best practices
+  // "ACT",             // W3C approved Accessibility Conformance Testing Rules
+  // "experimental",    // Cutting-edge rules
+];
+
+export const test = base.extend<{ a11yPage: AxePage }>({
+  a11yPage: async ({ page }, use) => {
+    const a11y = new AxePage(page);
+    await use(a11y);
+  },
+});
+
+const links = fs
+  .readFileSync("sitemap.links", "utf-8")
+  .split("\n")
+  .filter((link: string) => link !== "");
+
+links.forEach((link: string) => {
+  test(`Accessibility test for ${link}`, async ({ page, a11yPage }) => {
+    await page.goto(link);
+    await a11yPage.evaluate();
+  });
+});

--- a/tests/axe-sitemap.spec.ts
+++ b/tests/axe-sitemap.spec.ts
@@ -1,6 +1,6 @@
 import { test } from "@playwright/test";
 import { expect } from '@support/a11y-page';
-import fs from "fs";
+import getSitemapLinks from '@support/sitemap-links';
 
 const axe_tags = [
   "wcag2a",
@@ -15,12 +15,7 @@ const axe_tags = [
   // "experimental",    // Cutting-edge rules
 ];
 
-const links = fs
-  .readFileSync("sitemap.links", "utf-8")
-  .split("\n")
-  .filter((link: string) => link !== "");
-
-links.forEach((link: string) => {
+getSitemapLinks("sitemap.links").forEach((link: string) => {
   test(`Accessibility test for ${link}`, async ({ page }) => {
     await page.goto(link);
     await expect(page).toPassAxe(axe_tags);

--- a/tests/axe-sitemap.spec.ts
+++ b/tests/axe-sitemap.spec.ts
@@ -1,5 +1,5 @@
-import { test as base, expect } from "@playwright/test";
-import { AxePage } from '@support/a11y-page';
+import { test as base } from "@playwright/test";
+import { expect, AxePage } from '@support/a11y-page';
 import fs from "fs";
 
 const axe_tags = [
@@ -30,6 +30,6 @@ const links = fs
 links.forEach((link: string) => {
   test(`Accessibility test for ${link}`, async ({ page, a11yPage }) => {
     await page.goto(link);
-    await a11yPage.evaluate();
+    await expect(page).toBeAccessible({ page, axe_tags });
   });
 });

--- a/tests/axe-sitemap.spec.ts
+++ b/tests/axe-sitemap.spec.ts
@@ -1,6 +1,6 @@
 import { test } from "@playwright/test";
-import { expect } from '@support/a11y-page';
-import getSitemapLinks from '@support/sitemap-links';
+import { expect } from "@support/a11y-page";
+import getSitemapLinks from "@support/sitemap-links";
 
 const axe_tags = [
   "wcag2a",
@@ -18,6 +18,6 @@ const axe_tags = [
 getSitemapLinks("sitemap.links").forEach((link: string) => {
   test(`Accessibility test for ${link}`, async ({ page }) => {
     await page.goto(link);
-    await expect(page).toPassAxe(axe_tags);
+    await expect(page).toPassAxe({ tags: axe_tags });
   });
 });

--- a/tests/axe-sitemap.spec.ts
+++ b/tests/axe-sitemap.spec.ts
@@ -1,5 +1,5 @@
-import { test as base } from "@playwright/test";
-import { expect, AxePage } from '@support/a11y-page';
+import { test } from "@playwright/test";
+import { expect } from '@support/a11y-page';
 import fs from "fs";
 
 const axe_tags = [
@@ -15,21 +15,14 @@ const axe_tags = [
   // "experimental",    // Cutting-edge rules
 ];
 
-export const test = base.extend<{ a11yPage: AxePage }>({
-  a11yPage: async ({ page }, use) => {
-    const a11y = new AxePage(page);
-    await use(a11y);
-  },
-});
-
 const links = fs
   .readFileSync("sitemap.links", "utf-8")
   .split("\n")
   .filter((link: string) => link !== "");
 
 links.forEach((link: string) => {
-  test(`Accessibility test for ${link}`, async ({ page, a11yPage }) => {
+  test(`Accessibility test for ${link}`, async ({ page }) => {
     await page.goto(link);
-    await expect(page).toBeAccessible({ page, axe_tags });
+    await expect(page).toPassAxe(axe_tags);
   });
 });


### PR DESCRIPTION
## Axe Tests

### Description of work
- Adds axe testing via sitemap

### Functional testing steps:
- [ ] Run `npm run a11y https://yalesites-platform.lndo.site` (if you have a local instance, otherwise point to another site)