### PR TITLE
YSP-454: E2E Testing: Enable ignoring of iframe contents for Axe evaluation

### DIFF
--- a/support/axePage.ts
+++ b/support/axePage.ts
@@ -126,6 +126,9 @@ export class AxePage {
             axeBuilder.withTags(options.tags);
         }
 
+        // Exclude all iframes from axe evaluation to prevent reCAPTCHA violations
+        axeBuilder.exclude('iframe');
+
         this.axeBuilder = axeBuilder;
     }
 


### PR DESCRIPTION
## [YSP-454: E2E Testing: Enable ignoring of iframe contents for Axe evaluation](https://yaleits.atlassian.net/browse/YSP-454)

### Description of work
- Exclude all iframes from axe accessibility checks to prevent reCAPTCHA violations during automated testing.

### Functional testing steps:
- [ ] Run `YALESITES_URL="YOUR_TEST_URL" npm run test tests/components/pre-built-form.spec.ts`
- [ ] Ensure no iframe axe findings happen